### PR TITLE
Patch errors on missing sounds and particles

### DIFF
--- a/items/active/shields/shield.lua
+++ b/items/active/shields/shield.lua
@@ -272,8 +272,12 @@ function raiseShield()
 					if (self.energyval) >= 50 and (self.randomBash) >= 50 then -- Shield Bash when perfect blocking
 						bashEnemy()
 					end	  
+					--No catch case for this sound since it's required by vanilla.
 					animator.playSound("perfectBlock")
-					animator.burstParticleEmitter("perfectBlock")
+					
+					if self.animationData.particleEmitters and self.animationData.particleEmitters.perfectBlock then
+						animator.burstParticleEmitter("perfectBlock")
+					end
 					refreshPerfectBlock()
 				elseif status.resourcePositive("shieldStamina") then   
 					if (self.energyval) >= 50 and (self.randomBash) >= 100 then -- Shield Bash when perfect blocking


### PR DESCRIPTION
All non-vanilla sounds and particles have been given catch cases for if they don't exist to prevent errors from occurring when using them.

Vanilla sounds and particles will still error so that default behavior can be properly exhibited while not allowing any extra errors to occur for modded properties.